### PR TITLE
update config for catkin_make

### DIFF
--- a/src/libeSRS/config.h.in
+++ b/src/libeSRS/config.h.in
@@ -42,6 +42,6 @@
 #cmakedefine WITH_USBCAM 1
 #cmakedefine WITH_USBXI16P 1
 
-#cmakedefine PATH_YOLO_DIR "@YOLO_DIR@"
+#cmakedefine PATH_YOLO_DIR "@PATH_YOLO_DIR@"
 
 #endif


### PR DESCRIPTION
catkin_make時に 設定したexport PATH_DARKNET=$(pwd)が反映されていない為
対象となるファイルの編集を行いました。
こちらでビルドを試し、Darknetとの連動を確認しました。